### PR TITLE
escape newline unicode chars \u2028 and \u2029

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 *.orig
 .DS_Store
 coverage
+yarn.lock
 ~*

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -3,6 +3,7 @@
 const markerKey = Symbol('warp10');
 const safePropName = /^[$A-Z_][0-9A-Z_$]*$/i;
 const escapeEndingScriptTagRegExp = /<\//g;
+const lineAndParagraphSeparatorRegExp = /\u2028|\u2029/g;
 const isArray = Array.isArray;
 
 class Marker {
@@ -109,6 +110,12 @@ function serializeHelper(obj, safe, varName, additive) {
     if (safe) {
         json = json.replace(escapeEndingScriptTagRegExp, '\\u003C/');
     }
+
+    // No string in JavaScript can contain a literal U+2028 (Line separator) or a U+2029 (Paragraph separator)
+    // more info: http://timelessrepo.com/json-isnt-a-javascript-subset
+    json = json.replace(lineAndParagraphSeparatorRegExp, function (match) {
+      return '\\u' + match.charCodeAt(0).toString(16);
+    });
 
     if (varName) {
         if (additive) {

--- a/test/tests/newline-chars/test.js
+++ b/test/tests/newline-chars/test.js
@@ -1,0 +1,21 @@
+var expect = require('chai').expect;
+var fs = require('fs');
+var path = require('path');
+
+module.exports = function(helpers) {
+    var objWithSpecialChar = {
+        'foo-0': 'bar\u2028',
+        'foo-1': 'bar\u2029',
+        'foo-2': '\u2028bar\u2029'
+    };
+
+    var code = helpers.warp10.serialize(objWithSpecialChar, { var: 'obj' });
+
+    fs.writeFileSync(path.join(__dirname, 'actual-code.js'), code, { encoding: 'utf8' });
+
+    var window = helpers.browserLoad(code);
+
+    expect(window.obj['foo-0']).to.equal('bar\u2028');
+    expect(window.obj['foo-1']).to.equal('bar\u2029');
+    expect(window.obj['foo-2']).to.equal('\u2028bar\u2029');
+};


### PR DESCRIPTION
Escaping invalid unicode characters in javascript string

* `\u2028` - Line separator
* `\u2029` - Paragraph separator

http://timelessrepo.com/json-isnt-a-javascript-subset