### PR TITLE
Add noop constant serialization

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,6 @@
 {
     "node" : true,
+    "browser": true,
     "esnext": true,
     "boss" : false,
     "curly": false,

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,1 @@
+module.exports = require("./src/constants");

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,2 @@
+var win = typeof window !== "undefined" ? window : global;
+exports.NOOP = win.$W10NOOP = win.$W10NOOP || function () {};

--- a/src/finalize.js
+++ b/src/finalize.js
@@ -1,3 +1,4 @@
+var constants = require("./constants");
 var isArray = Array.isArray;
 
 function resolve(object, path, len) {
@@ -12,6 +13,8 @@ function resolve(object, path, len) {
 function resolveType(info) {
     if (info.type === 'Date') {
         return new Date(info.value);
+    } else if (info.type === 'NOOP') {
+        return constants.NOOP;
     } else {
         throw new Error('Bad type');
     }

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const constants = require("./constants");
 const markerKey = Symbol('warp10');
 const safePropName = /^[$A-Z_][0-9A-Z_$]*$/i;
 const isArray = Array.isArray;
@@ -27,7 +28,14 @@ class Marker {
 }
 
 function handleProperty(clone, key, value, valuePath, serializationSymbol, assignments) {
-    if (value.constructor === Date) {
+    if (value === constants.NOOP) {
+        if (assignments.$W10NOOP) {
+            assignments.push(valuePath + '=window.$W10NOOP');
+        } else {
+            assignments.$W10NOOP = true;
+            assignments.push(valuePath + '=window.$W10NOOP=window.$W10NOOP||function(){}');
+        }
+    } else if (value.constructor === Date) {
         assignments.push(valuePath + '=new Date(' + value.getTime() + ')');
     } else if (isArray(value)) {
         const marker = value[markerKey];
@@ -60,7 +68,7 @@ function pruneArray(array, path, serializationSymbol, assignments) {
             continue;
         }
 
-        if (value && typeof value === 'object') {
+        if (value && (value === constants.NOOP || typeof value === 'object')) {
             let valuePath = path + '[' + i + ']';
             handleProperty(clone, i, value, valuePath, serializationSymbol, assignments);
         } else {
@@ -80,7 +88,7 @@ function pruneObject(obj, path, serializationSymbol, assignments) {
             continue;
         }
 
-        if (value && typeof value === 'object') {
+        if (value && (value === constants.NOOP || typeof value === 'object' )) {
             let valuePath = path + (safePropName.test(key) ? '.' + key : '[' + JSON.stringify(key) + ']');
             handleProperty(clone, key, value, valuePath, serializationSymbol, assignments);
         } else {

--- a/src/stringifyPrepare.js
+++ b/src/stringifyPrepare.js
@@ -1,4 +1,5 @@
 'use strict';
+const constants = require("./constants");
 const markerKey = Symbol('warp10');
 const isArray = Array.isArray;
 
@@ -27,7 +28,9 @@ class Assignment {
 }
 
 function handleProperty(clone, key, value, valuePath, serializationSymbol, assignments) {
-    if (value.constructor === Date) {
+    if (value === constants.NOOP) {
+        assignments.push(new Assignment(valuePath, { type: 'NOOP' }));
+    } else if (value.constructor === Date) {
         assignments.push(new Assignment(valuePath, { type: 'Date', value: value.getTime() }));
     } else if (isArray(value)) {
         const marker = value[markerKey];
@@ -60,7 +63,7 @@ function pruneArray(array, path, serializationSymbol, assignments) {
             continue;
         }
 
-        if (value && typeof value === 'object') {
+        if (value && (value === constants.NOOP || typeof value === 'object')) {
             handleProperty(clone, i, value, append(path, i), serializationSymbol, assignments);
         } else {
             clone[i] = value;
@@ -93,7 +96,7 @@ function pruneObject(obj, path, serializationSymbol, assignments) {
             continue;
         }
 
-        if (value && typeof value === 'object') {
+        if (value && (value === constants.NOOP || typeof value === 'object')) {
             handleProperty(clone, key, value, append(path, key), serializationSymbol, assignments);
         } else {
             clone[key] = value;

--- a/test/test.js
+++ b/test/test.js
@@ -88,12 +88,10 @@ class Helpers {
         });
 
         var browserObj;
+        var window = browserObj = browserLoad(deserializationCode);
 
         if (varName) {
-            var window = browserLoad(deserializationCode);
             browserObj = window[varName];
-        } else {
-            browserObj = eval(deserializationCode);
         }
 
         var actual = safeStringify(browserObj);

--- a/test/tests/noop-fn/test.js
+++ b/test/tests/noop-fn/test.js
@@ -1,0 +1,6 @@
+const NOOP = require("../../../constants").NOOP;
+module.exports = function(helpers) {
+    helpers.browserVerify({
+        fn: NOOP
+    });
+};


### PR DESCRIPTION
This adds a special `noop` function which can be serialized to the browser and checked against.
Primarily this is to allow for a change in Marko which will improve the preservation of server side renderBodies being sent to the browser.

The implementation of this will likely change in the future and for now this API is not considered public.